### PR TITLE
Make plugin reload client when plugin gets unloaded

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,6 +41,7 @@ export default class amogus extends Plugin {
   }
 
   stop () {
-    unpatch('amoguspng')
+    unpatch('amoguspng');
+	window.location.reload()
   }
 }


### PR DESCRIPTION
This is because when the plugin is unloaded (disabled), artifacts of the plugin remain
A client reload will solve this inconveniently