### PR TITLE
Fix cilent reloading before plugin gets unloaded

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,6 +42,6 @@ export default class amogus extends Plugin {
 
   stop () {
     unpatch('amoguspng');
-	window.location.reload()
+	setTimeout(() => window.location.reload(), 2000)
   }
 }


### PR DESCRIPTION
This fixes a bug introduced by this commit (0abe7393f12f6a33710b45882e4ea6d3b23d3089) that makes the client reload before the plugin gets unloaded
Unless you want the user unable to disable the plugin, this pull request fixes the bug by making the client sleep for 2 seconds after it has unloaded the plugin, then, proceed to reload the client